### PR TITLE
Add curl_error handling

### DIFF
--- a/core/sfsapi.php
+++ b/core/sfsapi.php
@@ -112,12 +112,14 @@ class sfsapi
 		]);
 
 		$contents = curl_exec($ch);
+		$curl_error = curl_error($ch);
 		$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		curl_close($ch);
 
 		// if nothing is returned (SFS is down)
 		if ($httpcode != 200)
 		{
+			$this->error_message = $curl_error;
 			return false;
 		}
 
@@ -127,6 +129,17 @@ class sfsapi
 		}
 
 		return $contents;
+	}
+
+/*
+	* sfsapi
+	* @param 	$response		object containing the error message response to be retrieved
+	* @return 	string			return either a string on success or false on failure
+	*/
+
+	public function sfs_get_curl_error($response)
+	{
+		return $this->error_message;
 	}
 
 	/*

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -464,6 +464,9 @@ class main_listener implements EventSubscriberInterface
 
 		// Query the SFS database and pull the data into script
 		$json = $this->sfsapi->sfsapi('query', $username, $ip, $email);
+		if (!$json) {
+			$curl_error = $this->sfsapi->sfs_get_curl_error($json);
+		}
 		$json_decode = json_decode($json, true);
 
 		// Check if user is a spammer, but only if we successfully got the SFS data
@@ -510,13 +513,18 @@ class main_listener implements EventSubscriberInterface
 		{
 			if ($sfs_log_message)
 			{
-				if ($this->config['sfs_down'])
-				{
-					$this->log_message('admin', $username, $ip, 'LOG_SFS_DOWN_USER_ALLOWED', $email);
+				if (!$curl_error) {
+					if ($this->config['sfs_down'])
+					{
+						$this->log_message('admin', $username, $ip, 'LOG_SFS_DOWN_USER_ALLOWED', $email);
+					}
+					else
+					{
+						$this->log_message('admin', $username, $ip, 'LOG_SFS_DOWN', $email);
+					}
 				}
-				else
-				{
-					$this->log_message('admin', $username, $ip, 'LOG_SFS_DOWN', $email);
+				else {
+					$this->log_message('admin', $username, $ip, 'Stop Forum Spam was unreachable during a registration or a forum post. <br> <b>CURL Error</b>: ' . $curl_error, $email);
 				}
 			}
 			return 'sfs_down';


### PR DESCRIPTION
I've started the work on handling curl errors, but I'm having trouble understanding how the message logger works.
I think changes might need to be made to allow the message logger to handle error text in addition to the predefined language-based errors.

This addresses #45 